### PR TITLE
Add tests and a basic fix for timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 test_*.*
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Some simple examples are available in the [examples/](examples/) folder.
 
 ## Contributing
 The roadmap is available on [Trello](https://trello.com/b/wzVH18Fd/gpcp "GPCP On Trello"). Now gpcp is not so ready to use it in projects but it will, if you find problems or want to give a suggestion please open an issue here.
+
+## Testing
+
+Testing the project requires the following `pip` packages: `pytest`, `pytest-reraise`.
+
+Just run `pytest` in the root directory to run all tests.

--- a/gpcp/__init__.py
+++ b/gpcp/__init__.py
@@ -1,0 +1,5 @@
+# import things to expose to users here
+from gpcp.client import Client
+from gpcp.server import Server
+from gpcp.core.base_handler import BaseHandler
+from gpcp.utils.annotations import command, unknownCommand

--- a/gpcp/core/dispatcher.py
+++ b/gpcp/core/dispatcher.py
@@ -1,32 +1,17 @@
 from socket import timeout as socket_timeout
-from threading import Event, Thread
+from threading import Thread
+from queue import Queue
 import logging
 from gpcp.core import packet
 
 logger = logging.getLogger(__name__)
 
-class BufferEvent:
-    def __init__(self):
-        self.update = Event()
-        self.buffer = []
-
-    def waitForUpdate(self, timeout=5):
-        if len(self.buffer) != 0:
-            return self.buffer.pop(0)
-
-        self.update.wait(timeout)
-        if len(self.buffer) != 0:
-            return self.buffer.pop(0)
-
-        self.update.clear()
-        raise TimeoutError()
-
 class Dispatcher:
 
     def __init__(self, socket, timeout: float = 0.1):
         #initialize the event triggers
-        self.request = BufferEvent()
-        self.response = BufferEvent()
+        self.request = Queue()
+        self.response = Queue()
         self.socket = socket
         self.socket.settimeout(timeout)
         self._stop = False
@@ -37,9 +22,6 @@ class Dispatcher:
 
     def startReceiver(self):
         while not self._stop:
-            self.request.update.clear()
-            self.response.update.clear()
-
             try:
                 data, isRequest = packet.receiveAll(self.socket)
             except TimeoutError:
@@ -47,25 +29,18 @@ class Dispatcher:
 
             if data is None: # connection was closed
                 logger.debug(f"received None from {self.socket.getpeername()}, terminating dispatcher")
-                self.request.buffer.append(None)
-                self.response.buffer.append(None)
-
-                self.request.update.set()
-                self.response.update.set()
-
-                self._stop = True
+                self.stopReceiver()
 
             else:
                 if isRequest:
                     logger.debug(f"received request: {data}")
-                    self.request.buffer.append(data)
-                    self.request.update.set()
+                    self.request.put(data)
                 else:
                     logger.debug(f"received response: {data}")
-                    self.response.buffer.append(data)
-                    self.response.update.set()
+                    self.response.put(data)
 
-    def setStopFlag(self):
-        self.request.update.set()
-        self.response.update.set()
+    def stopReceiver(self):
+        # sending None to request and response makes sure the endpoint closes, too
+        self.request.put(None)
+        self.response.put(None)
         self._stop = True

--- a/gpcp/core/dispatcher.py
+++ b/gpcp/core/dispatcher.py
@@ -32,7 +32,7 @@ class Dispatcher:
         self._stop = False
 
         self.thread = Thread(target=self.startReceiver)
-        self.thread.setName(f"{self.socket.getsockname()} dispatcher")
+        self.thread.name = f"{self.socket.getsockname()} dispatcher"
         self.thread.start()
 
     def startReceiver(self):

--- a/gpcp/core/endpoint.py
+++ b/gpcp/core/endpoint.py
@@ -93,7 +93,7 @@ class EndPoint():
 
     def startMainLoopThread(self):
         self.mainLoopThread = Thread(target=self.mainLoop)
-        self.mainLoopThread.setName(f"connection ({self.remoteAddress[0]}:{self.remoteAddress[1]})")
+        self.mainLoopThread.name = f"connection ({self.remoteAddress[0]}:{self.remoteAddress[1]})"
         self.mainLoopThread.start()
 
     def _closeConnection(self, calledFromMainLoopThread: bool):

--- a/gpcp/core/endpoint.py
+++ b/gpcp/core/endpoint.py
@@ -73,11 +73,8 @@ class EndPoint():
         self._finishedInitializing = True
 
         while not self._stop:
-            #wait for a request to come
-            try:
-                data = self.dispatcher.request.waitForUpdate()
-            except TimeoutError:
-                continue
+            # wait for a request to come
+            data = self.dispatcher.request.get()
 
             if data is None: # connection was closed
                 logger.info(f"received None data from {self.remoteAddress}, closing connection")
@@ -110,8 +107,7 @@ class EndPoint():
         else:
             # set stop flags for threads: dispatcher.setStopFlag() also sets events for request/response buffers
             self._stop = True
-            if self._finishedInitializing:
-                self.dispatcher.setStopFlag()
+            self.dispatcher.stopReceiver()
 
             if not calledFromMainLoopThread:
                 # first join our thread, which should be instant since events for request/response buffers were set
@@ -202,8 +198,8 @@ class EndPoint():
         data = packet.CommandData.encode(commandIdentifier, arguments)
         #send the request
         packet.sendAll(self.socket, data, isRequest=True)
-        #wait for the response trigger to activate and load the response
-        response = self.dispatcher.response.waitForUpdate()
+        # wait for a response to be enqueued to the response queue
+        response = self.dispatcher.response.get()
         result = json.loads(response.decode(packet.ENCODING))
         logger.debug(f"commandRequest() received result={result}")
         return result

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+# allows running `python3 test/XXX_test.py` from the root directory
+# and the included `gpcp` module will be the local one
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/test/long_timeout_test.py
+++ b/test/long_timeout_test.py
@@ -13,6 +13,10 @@ def runServer():
         def waitSomeTime(self) -> None:
             time.sleep(SLEEP_SECONDS)
 
+        @gpcp.command
+        def anotherCommand(self, a: str) -> str:
+            return a + a
+
     global server
     with gpcp.Server(handler=ServerHandler) as server:
         server.startServer(HOST, PORT)
@@ -20,7 +24,9 @@ def runServer():
 def runClient():
     with gpcp.Client(HOST, PORT) as client:
         client.loadInterface(client)
+        assert client.anotherCommand("abc") == "abcabc"
         client.waitSomeTime()
+        assert client.anotherCommand("abcd") == "abcdabcd"
 
 
 def test_longTimeout(reraise):

--- a/test/long_timeout_test.py
+++ b/test/long_timeout_test.py
@@ -1,0 +1,41 @@
+import time
+import threading
+import gpcp
+import sys
+
+HOST = "0.0.0.0"
+PORT = 9134
+SLEEP_SECONDS = 8
+
+def runServer():
+    class ServerHandler(gpcp.BaseHandler):
+        @gpcp.command
+        def waitSomeTime(self) -> None:
+            time.sleep(SLEEP_SECONDS)
+
+    global server
+    with gpcp.Server(handler=ServerHandler) as server:
+        server.startServer(HOST, PORT)
+
+def runClient():
+    with gpcp.Client(HOST, PORT) as client:
+        client.loadInterface(client)
+        client.waitSomeTime()
+
+
+def test_longTimeout(reraise):
+    serverThread = threading.Thread(target=reraise.wrap(runServer))
+    serverThread.start()
+
+    clientThreads = [threading.Thread(target=reraise.wrap(runClient)) for i in range(5)]
+    for thread in clientThreads:
+        thread.start()
+
+    startTime = time.time()
+    for thread in clientThreads:
+        thread.join()
+    takenTime = time.time() - startTime
+    assert takenTime < 2 * SLEEP_SECONDS
+
+    server.stopServer()
+    serverThread.join()

--- a/test/long_timeout_test.py
+++ b/test/long_timeout_test.py
@@ -5,13 +5,14 @@ import sys
 
 HOST = "0.0.0.0"
 PORT = 9134
-SLEEP_SECONDS = 8
+SECONDS = 8
+CLIENTS = 5
 
 def runServer():
     class ServerHandler(gpcp.BaseHandler):
         @gpcp.command
         def waitSomeTime(self) -> None:
-            time.sleep(SLEEP_SECONDS)
+            time.sleep(SECONDS)
 
         @gpcp.command
         def anotherCommand(self, a: str) -> str:
@@ -33,7 +34,7 @@ def test_longTimeout(reraise):
     serverThread = threading.Thread(target=reraise.wrap(runServer))
     serverThread.start()
 
-    clientThreads = [threading.Thread(target=reraise.wrap(runClient)) for i in range(5)]
+    clientThreads = [threading.Thread(target=reraise.wrap(runClient)) for i in range(CLIENTS)]
     for thread in clientThreads:
         thread.start()
 
@@ -41,7 +42,7 @@ def test_longTimeout(reraise):
     for thread in clientThreads:
         thread.join()
     takenTime = time.time() - startTime
-    assert takenTime < 2 * SLEEP_SECONDS
+    assert takenTime < 2 * SECONDS
 
     server.stopServer()
     serverThread.join()

--- a/test/stress_test.py
+++ b/test/stress_test.py
@@ -1,0 +1,58 @@
+import time
+import threading
+import gpcp
+import sys
+import random
+
+HOST = "0.0.0.0"
+PORT = 9135
+SECONDS = 5
+CLIENTS = 32
+
+FIBONACCI = [
+    1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946,
+    17711, 28657, 46368, 75025, 121393, 196418, 317811, 514229, 832040, 1346269, 2178309, 3524578,
+    5702887, 9227465, 14930352, 24157817, 39088169, 63245986, 102334155
+]
+
+def runServer():
+    class ServerHandler(gpcp.BaseHandler):
+        @gpcp.command
+        def fibonacci(self, i: int) -> int:
+            def fib(x):
+                if x < 2:
+                    return 1
+                else:
+                    return fib(x-1) + fib(x-2)
+            return fib(i)
+
+    global server
+    with gpcp.Server(handler=ServerHandler) as server:
+        server.startServer(HOST, PORT)
+
+def runClient():
+    with gpcp.Client(HOST, PORT) as client:
+        client.loadInterface(client)
+
+        initialTime = time.time()
+        while time.time() - initialTime < SECONDS:
+            i = random.randint(25, 31)
+            assert client.fibonacci(i) == FIBONACCI[i]
+
+
+def test_stress(reraise):
+    serverThread = threading.Thread(target=reraise.wrap(runServer))
+    serverThread.start()
+
+    clientThreads = [threading.Thread(target=reraise.wrap(runClient)) for i in range(CLIENTS)]
+    for thread in clientThreads:
+        thread.start()
+
+    startTime = time.time()
+    for thread in clientThreads:
+        thread.join()
+    takenTime = time.time() - startTime
+    assert takenTime < 8 * SECONDS
+
+    server.stopServer()
+    serverThread.join()


### PR DESCRIPTION
Before the client was timing out after an hardcoded 5 seconds of waiting for a response. Now that was removed.

I also added a test for timeout (it takes 8 seconds to run!). Obviously tests should be expanded in the future.

The `BufferEvent` was removed in favor of python's `Queue`, which contains all of the methods we need.